### PR TITLE
fixed to delete duplicated gameObject.

### DIFF
--- a/Plugins/HockeyAppUnityAndroid/HockeyAppUnity-Scripts/HockeyAppAndroid.cs
+++ b/Plugins/HockeyAppUnityAndroid/HockeyAppUnity-Scripts/HockeyAppAndroid.cs
@@ -46,6 +46,7 @@ public class HockeyAppAndroid : MonoBehaviour
 
 		#if (UNITY_ANDROID && !UNITY_EDITOR)
 		if (instance != null) {
+			Destroy(gameObject);
 			return;
 		}
 


### PR DESCRIPTION
When the scene is reloaded, a new HockeyApp gameObject is instantiated. If `instance` is valid, we should destroy the new one.